### PR TITLE
(Fixes #357) Adding recursive option to the GoogleStorageDowloadActivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.5 - 2016-04-11
+### Added
+- [#357](https://github.com/krux/hyperion/issues/357) - Add recursive option to GoogleStorageDownloadActivity
+
 ## 3.2.4 - 2016-03-29
 ### Added
-- [#321](https://github.com/krux/hyperion/issues/321) - Add overloaded methods accepting HS3Uri for Activities 
+- [#321](https://github.com/krux/hyperion/issues/321) - Add overloaded methods accepting HS3Uri for Activities
 
 ## 3.2.3 - 2016-03-28
 ### Added

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,1 +1,2 @@
 Lee Baker (bakerlee)
+Arijit Dey (arijitdey)

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "3.2.4"
+val hyperionVersion = "3.2.5"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.7"
 val awsSdkVersion   = "1.10.43"

--- a/contrib/activity/definition/src/main/scala/com/krux/hyperion/activity/GoogleStorageDownloadActivity.scala
+++ b/contrib/activity/definition/src/main/scala/com/krux/hyperion/activity/GoogleStorageDownloadActivity.scala
@@ -1,10 +1,10 @@
 package com.krux.hyperion.activity
 
 import com.krux.hyperion.HyperionContext
-import com.krux.hyperion.adt.{ HS3Uri, HString }
-import com.krux.hyperion.common.{ BaseFields, PipelineObjectId }
+import com.krux.hyperion.adt.{HBoolean, HS3Uri, HString}
+import com.krux.hyperion.common.{BaseFields, PipelineObjectId}
 import com.krux.hyperion.expression.RunnableObject
-import com.krux.hyperion.resource.{ Ec2Resource, Resource }
+import com.krux.hyperion.resource.{Ec2Resource, Resource}
 
 /**
  * Google Storage Download activity
@@ -14,7 +14,8 @@ case class GoogleStorageDownloadActivity private (
   activityFields: ActivityFields[Ec2Resource],
   shellCommandActivityFields: ShellCommandActivityFields,
   botoConfigUrl: HS3Uri,
-  googleStorageUri: HString
+  googleStorageUri: HString,
+  ignoreMissingSource: HBoolean
 ) extends GoogleStorageActivity with WithS3Output {
 
   type Self = GoogleStorageDownloadActivity
@@ -22,6 +23,14 @@ case class GoogleStorageDownloadActivity private (
   def updateBaseFields(fields: BaseFields) = copy(baseFields = fields)
   def updateActivityFields(fields: ActivityFields[Ec2Resource]) = copy(activityFields = fields)
   def updateShellCommandActivityFields(fields: ShellCommandActivityFields) = copy(shellCommandActivityFields = fields)
+
+  def ifExists = copy(ignoreMissingSource = true)
+
+  override def scriptArguments = Seq(
+    botoConfigUrl.serialize: HString,
+    googleStorageUri,
+    ignoreMissingSource.serialize
+  )
 
 }
 
@@ -33,7 +42,8 @@ object GoogleStorageDownloadActivity extends RunnableObject {
       activityFields = ActivityFields(runsOn),
       shellCommandActivityFields = ShellCommandActivityFields(GoogleStorageActivity.downloadScript),
       botoConfigUrl = botoConfigUrl,
-      googleStorageUri = input
+      googleStorageUri = input,
+      ignoreMissingSource = HBoolean.False
     )
 
 }

--- a/examples/src/main/scala/com/krux/hyperion/examples/ExampleWorkflow.scala
+++ b/examples/src/main/scala/com/krux/hyperion/examples/ExampleWorkflow.scala
@@ -1,10 +1,11 @@
 package com.krux.hyperion.examples
 
 import com.krux.hyperion.Implicits._
-import com.krux.hyperion.activity.ShellCommandActivity
+import com.krux.hyperion.activity.{GoogleStorageDownloadActivity, ShellCommandActivity}
+import com.krux.hyperion.datanode.S3DataNode
 import com.krux.hyperion.expression.Parameter
 import com.krux.hyperion.resource.Ec2Resource
-import com.krux.hyperion.{ DataPipelineDef, HyperionCli, HyperionContext, Schedule }
+import com.krux.hyperion.{DataPipelineDef, HyperionCli, HyperionContext, Schedule}
 import com.typesafe.config.ConfigFactory
 
 object ExampleWorkflow extends DataPipelineDef with HyperionCli {
@@ -29,11 +30,13 @@ object ExampleWorkflow extends DataPipelineDef with HyperionCli {
   val act4 = ShellCommandActivity("run act4")(ec2).named("act4")
   val act5 = ShellCommandActivity("run act5")(ec2).named("act5")
   val act6 = ShellCommandActivity("run act6")(ec2).named("act6")
+  val act7 = GoogleStorageDownloadActivity(s3 / "gsutil.config", "gs://input_location")(ec2).named("act7")
+  val act8 = GoogleStorageDownloadActivity(s3 / "gsutil.config", "gs://input_location")(ec2).named("act8").ifExists
 
   // run act1 first, and then run act2 and act3 at the same time, and then run act4 and act5 the
   // same time, at last run act6
   // Anoternative syntax would be:
   // act1 andThen (act2 and act3) andThen (act4 and act5) andThen act6
-  override def workflow = act1 ~> (act2 + act3) ~> (act4 + act5) ~> act6
+  override def workflow = act1 ~> (act2 + act3) ~> (act4 + act5) ~> act6 ~> act7 ~> act8
 
 }

--- a/examples/src/test/scala/com/krux/hyperion/examples/ExampleWorkflowSpec.scala
+++ b/examples/src/test/scala/com/krux/hyperion/examples/ExampleWorkflowSpec.scala
@@ -14,7 +14,7 @@ class ExampleWorkflowSpec extends WordSpec {
       val pipelineJson: JValue = ExampleWorkflow
       val objectsField = (pipelineJson \ "objects").children.sortBy(o => (o \ "name").toString)
 
-      assert(objectsField.size === 9)  // 6 activities, 1 default, 1 schedule, 1 ec2 resource
+      assert(objectsField.size === 11)  // 8 activities, 1 default, 1 schedule, 1 ec2 resource
 
       // the first object should be Default
       val defaultObj = objectsField.head
@@ -127,6 +127,32 @@ class ExampleWorkflowSpec extends WordSpec {
         ("dependsOn" -> List("ref" -> act4Id, "ref" -> act5Id).sorted) ~
         ("type" -> "ShellCommandActivity")
       assert(act6ShouldBe === act6)
+
+      val act7 = objectsField(9)
+      val act7Id = (act7 \ "id").values.toString
+      assert(act7Id.startsWith("GoogleStorageDownloadActivity"))
+      val act7ShouldBe =
+        ("id" -> act7Id) ~
+        ("name" -> "act7") ~
+        ("scriptUri" -> "s3://your-bucket/datapipeline/scripts/activities/gsutil-download.sh") ~
+        ("scriptArgument" -> List("s3://gsutil.config", "gs://input_location", "false")) ~
+        ("runsOn" -> ("ref" -> ec2Id)) ~
+        ("dependsOn" -> List("ref" -> act6Id)) ~
+        ("type" -> "ShellCommandActivity")
+      assert(act7ShouldBe === act7)
+
+      val act8 = objectsField(10)
+      val act8Id = (act8 \ "id").values.toString
+      assert(act7Id.startsWith("GoogleStorageDownloadActivity"))
+      val act8ShouldBe =
+        ("id" -> act8Id) ~
+        ("name" -> "act8") ~
+        ("scriptUri" -> "s3://your-bucket/datapipeline/scripts/activities/gsutil-download.sh") ~
+        ("scriptArgument" -> List("s3://gsutil.config", "gs://input_location", "true")) ~
+        ("runsOn" -> ("ref" -> ec2Id)) ~
+        ("dependsOn" -> List("ref" -> act7Id)) ~
+        ("type" -> "ShellCommandActivity")
+      assert(act8ShouldBe === act8)
 
     }
   }


### PR DESCRIPTION
Currently GoogleStorageDownloadActivity supports copying of strictly folders and not specific file. Adding support for recursive option so that consumers can download both files and folders.