### PR TITLE
(Fixes #360) Ignoring AMI version if release label is set and vice-versa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.6 - 2016-04-15
+### Added
+- [#360](https://github.com/krux/hyperion/issues/360) - Unable to create MapReduceCluster with release Label
+
 ## 3.2.5 - 2016-04-11
 ### Added
 - [#357](https://github.com/krux/hyperion/issues/357) - Add recursive option to GoogleStorageDownloadActivity

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "3.2.5"
+val hyperionVersion = "3.2.6"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.7"
 val awsSdkVersion   = "1.10.43"

--- a/core/src/main/scala/com/krux/hyperion/resource/EmrCluster.scala
+++ b/core/src/main/scala/com/krux/hyperion/resource/EmrCluster.scala
@@ -17,7 +17,7 @@ trait EmrCluster extends ResourceObject {
 
   def amiVersion = emrClusterFields.amiVersion
   def withAmiVersion(version: HString): Self = updateEmrClusterFields(
-    emrClusterFields.copy(amiVersion = (Option(version)))
+    emrClusterFields.copy(amiVersion = Option(version), releaseLabel = None)
   )
 
   def supportedProducts = emrClusterFields.supportedProducts
@@ -112,7 +112,7 @@ trait EmrCluster extends ResourceObject {
 
   def releaseLabel = emrClusterFields.releaseLabel
   def withReleaseLabel(label: HString): Self = updateEmrClusterFields(
-    emrClusterFields.copy(releaseLabel = Option(label))
+    emrClusterFields.copy(releaseLabel = Option(label), amiVersion = None)
   )
 
   def applications = emrClusterFields.applications

--- a/examples/src/main/scala/com/krux/hyperion/examples/ExampleMapReduce.scala
+++ b/examples/src/main/scala/com/krux/hyperion/examples/ExampleMapReduce.scala
@@ -1,0 +1,78 @@
+package com.krux.hyperion.examples
+
+import scala.language.postfixOps
+import com.krux.hyperion.Implicits._
+import com.krux.hyperion.action.SnsAlarm
+import com.krux.hyperion.activity._
+import com.krux.hyperion.common.S3Uri
+import com.krux.hyperion.datanode.S3DataNode
+import com.krux.hyperion.expression.{Format, Parameter, RuntimeNode}
+import com.krux.hyperion.resource.{MapReduceCluster}
+import com.krux.hyperion.{DataPipelineDef, HyperionContext, Schedule, _}
+import com.typesafe.config.ConfigFactory
+
+object ExampleMapReduce extends DataPipelineDef with HyperionCli {
+
+  val target = "the-target"
+  val jar = s3 / "sample-jars" / "sample-jar-assembly-current.jar"
+
+  override implicit val hc: HyperionContext = new HyperionContext(ConfigFactory.load("example"))
+
+  override lazy val tags = Map("example" -> None, "ownerGroup" -> Some("mapReduce"))
+
+  override lazy val schedule = Schedule.cron
+    .startAtActivation
+    .every(1.day)
+    .stopAfter(3)
+
+  val location = Parameter[S3Uri]("S3Location").withValue(s3"your-location")
+  val instanceType = Parameter[String]("InstanceType").withValue("c3.8xlarge")
+  val instanceCount = Parameter("InstanceCount", 8)
+  val instanceBid = Parameter("InstanceBid", 3.40)
+
+  override def parameters: Iterable[Parameter[_]] = Seq(location, instanceType, instanceCount, instanceBid)
+
+  // Actions
+  val mailAction = SnsAlarm("arn:aws:sns:us-east-1:28619EXAMPLE:ExampleTopic")
+    .withSubject(s"Something happened at ${RuntimeNode.ScheduledStartTime}")
+    .withMessage(s"Some message $instanceCount x $instanceType @ $instanceBid for $location")
+    .withRole("DataPipelineDefaultResourceRole")
+
+  // Resources
+  val emrCluster = MapReduceCluster()
+    .withTaskInstanceCount(instanceCount)
+    .withTaskInstanceType(instanceType)
+    .withReleaseLabel("emr-4.4.0")
+    .named("Cluster with release label")
+
+  // First activity
+  val filterActivity = MapReduceActivity(emrCluster)
+    .named("filterActivity")
+    .onFail(mailAction)
+    .withSteps(
+      MapReduceStep(jar)
+        .withMainClass("com.krux.hyperion.ScoreJob1")
+        .withArguments(
+          target,
+          Format(SparkActivity.ScheduledStartTime - 3.days, "yyyy-MM-dd")
+        )
+    )
+
+  // Second activity
+  val scoreActivity = MapReduceActivity(emrCluster)
+    .named("scoreActivity")
+    .onSuccess(mailAction)
+    .withSteps(
+      MapReduceStep(jar)
+        .withMainClass("com.krux.hyperion.ScoreJob2")
+        .withArguments(
+          target,
+      Format(SparkActivity.ScheduledStartTime - 3.days, "yyyy-MM-dd"),
+      "denormalized"
+        )
+    )
+
+  override def workflow = filterActivity ~> scoreActivity
+
+}
+


### PR DESCRIPTION
We were unable to create MapReduceCluster with release Label as it was throwing the following error - Either AMI Version (or) Release Label should be specified, not both