### PR TITLE
(Fixes #365) Removing bootstrap action when using emr label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.8 - 2016-04-18
+### Added
+- [#365](https://github.com/krux/hyperion/issues/365) - Native applications are no longer configured by bootstrap actions but by configurations in EMR release label 4.X
+
 ## 3.2.7 - 2016-04-16
 ### Added
 - [#362](https://github.com/krux/hyperion/issues/362) - Do not emit empty arrays for EmrConfiguration properties

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "3.2.7"
+val hyperionVersion = "3.2.8"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.7"
 val awsSdkVersion   = "1.10.43"

--- a/core/src/main/scala/com/krux/hyperion/resource/EmrCluster.scala
+++ b/core/src/main/scala/com/krux/hyperion/resource/EmrCluster.scala
@@ -112,7 +112,12 @@ trait EmrCluster extends ResourceObject {
 
   def releaseLabel = emrClusterFields.releaseLabel
   def withReleaseLabel(label: HString): Self = updateEmrClusterFields(
-    emrClusterFields.copy(releaseLabel = Option(label), amiVersion = None)
+    emrClusterFields.copy(
+      releaseLabel = Option(label),
+      amiVersion = None,
+      standardBootstrapAction = Seq.empty,
+      bootstrapAction = Seq.empty
+    )
   )
 
   def applications = emrClusterFields.applications
@@ -142,6 +147,11 @@ trait EmrCluster extends ResourceObject {
       logger.warn("Server side expression cannot be evaluated. Unchecked comparison.")
       true
     })
+
+    assert(if (releaseLabel.nonEmpty) {
+      logger.warn("Native applications are no longer configured by bootstrap actions but by configurations in EMR release label 4.X")
+      true
+    } else { true })
 
     new AdpEmrCluster(
       id = id,

--- a/examples/src/test/scala/com/krux/hyperion/examples/ExampleMapReduceSpec.scala
+++ b/examples/src/test/scala/com/krux/hyperion/examples/ExampleMapReduceSpec.scala
@@ -58,7 +58,7 @@ class ExampleMapReduceSpec extends WordSpec {
       val mapReduceClusterShouldBe =
         ("id" -> mapReduceClusterId) ~
         ("name" -> "Cluster with release label") ~
-        ("bootstrapAction" -> List("s3://your-bucket/datapipeline/scripts/deploy-hyperion-emr-env.sh,s3://bucket/org_env.sh")) ~
+        ("bootstrapAction" -> JArray(List.empty)) ~
         ("masterInstanceType" -> "m3.xlarge") ~
         ("coreInstanceType" -> "m3.xlarge") ~
         ("coreInstanceCount" -> "2") ~


### PR DESCRIPTION
Native applications are no longer configured by bootstrap actions but by configurations in EMR release label 4.X