### PR TITLE
(Fixes #370) The standard bootstrap script now fails on older version of AMI (< 3.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.2.9 - 2016-04-20
+### Added
+- [#370](https://github.com/krux/hyperion/issues/370) - The standard bootstrap script now fails on older version of AMI (< 3.x)
+
 ## 3.2.8 - 2016-04-19
 ### Added
 - [#365](https://github.com/krux/hyperion/issues/365) - Change standard bootstrap action to use aws cli instead of hadoop

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,2 +1,3 @@
 Lee Baker (bakerlee)
 Arijit Dey (arijitdey)
+Anton Winter (antonwinter)

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "3.2.8"
+val hyperionVersion = "3.2.9"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.7"
 val awsSdkVersion   = "1.10.43"

--- a/scripts/deploy-hyperion-emr-env.sh
+++ b/scripts/deploy-hyperion-emr-env.sh
@@ -13,6 +13,11 @@ ENV_FILE="/home/hadoop/hyperion_env.sh"
 rm -f ${ENV_FILE}
 
 echo "Downloading env file from ${S3_ENV_FILE}"
-aws s3 cp ${S3_ENV_FILE} ${ENV_FILE}
+if [ -x "$(command -v aws)" ];
+then
+    aws s3 cp ${S3_ENV_FILE} ${ENV_FILE}
+else
+    hadoop fs -get ${S3_ENV_FILE} ${ENV_FILE}
+fi
 
 echo "Done!"


### PR DESCRIPTION
Adding support for ami versions < 4.x and EMR release label bootstrap actions. 