### PR TITLE
(Fixes #369) Making the SparkExample and SparkCluster compatible with…

### DIFF
--- a/contrib/activity/definition/src/test/resources/example.conf
+++ b/contrib/activity/definition/src/test/resources/example.conf
@@ -16,8 +16,6 @@ hyperion {
             instance.type = "m3.xlarge"
             ami.version = "3.3"
             terminate = "8 hours"
-            spark.version = "1.1.1.e"
-            env.uri = "s3://bucket/org_env.sh"
         }
     }
 }

--- a/core/src/main/scala/com/krux/hyperion/resource/SparkCluster.scala
+++ b/core/src/main/scala/com/krux/hyperion/resource/SparkCluster.scala
@@ -12,8 +12,7 @@ import com.krux.hyperion.HyperionContext
 case class SparkCluster private (
   baseFields: BaseFields,
   resourceFields: ResourceFields,
-  emrClusterFields: EmrClusterFields,
-  sparkVersion: HString
+  emrClusterFields: EmrClusterFields
 ) extends EmrCluster {
 
   type Self = SparkCluster
@@ -24,12 +23,6 @@ case class SparkCluster private (
   def updateResourceFields(fields: ResourceFields) = copy(resourceFields = fields)
   def updateEmrClusterFields(fields: EmrClusterFields) = copy(emrClusterFields = fields)
 
-  def withSparkVersion(sparkVersion: HString) = copy(sparkVersion = sparkVersion)
-
-  override def standardBootstrapAction = 
-    (s"s3://support.elasticmapreduce/spark/install-spark,-v,${sparkVersion},-x": HString) +:
-    super.standardBootstrapAction
-
 }
 
 object SparkCluster {
@@ -37,8 +30,7 @@ object SparkCluster {
   def apply()(implicit hc: HyperionContext): SparkCluster = new SparkCluster(
     baseFields = BaseFields(PipelineObjectId(SparkCluster.getClass)),
     resourceFields = EmrCluster.defaultResourceFields(hc),
-    emrClusterFields = EmrCluster.defaultEmrClusterFields(hc),
-    sparkVersion = hc.emrSparkVersion.get
+    emrClusterFields = EmrCluster.defaultEmrClusterFields(hc).copy(applications = Seq("spark"), standardBootstrapAction = Seq())
   )
 
 }

--- a/core/src/test/resources/example.conf
+++ b/core/src/test/resources/example.conf
@@ -14,10 +14,8 @@ hyperion {
 
         emr {
             instance.type = "m3.xlarge"
-            ami.version = "3.3"
+            ami.version = "4.3"
             terminate = "8 hours"
-            spark.version = "1.1.1.e"
-            env.uri = "s3://bucket/org_env.sh"
         }
     }
 }

--- a/examples/src/main/resources/example.conf
+++ b/examples/src/main/resources/example.conf
@@ -14,10 +14,8 @@ hyperion {
 
         emr {
             instance.type = "m3.xlarge"
-            ami.version = "3.3"
+            ami.version = "4.3"
             terminate = "8 hours"
-            spark.version = "1.1.1.e"
-            env.uri = "s3://bucket/org_env.sh"
         }
     }
 }

--- a/examples/src/test/scala/com/krux/hyperion/examples/ExampleMapReduceSpec.scala
+++ b/examples/src/test/scala/com/krux/hyperion/examples/ExampleMapReduceSpec.scala
@@ -58,7 +58,7 @@ class ExampleMapReduceSpec extends WordSpec {
       val mapReduceClusterShouldBe =
         ("id" -> mapReduceClusterId) ~
         ("name" -> "Cluster with release label") ~
-        ("bootstrapAction" -> List("s3://your-bucket/datapipeline/scripts/deploy-hyperion-emr-env.sh,s3://bucket/org_env.sh")) ~
+        ("bootstrapAction" -> List[String]()) ~
         ("masterInstanceType" -> "m3.xlarge") ~
         ("coreInstanceType" -> "m3.xlarge") ~
         ("coreInstanceCount" -> "2") ~

--- a/examples/src/test/scala/com/krux/hyperion/examples/ExampleS3DistCpWorkflowSpec.scala
+++ b/examples/src/test/scala/com/krux/hyperion/examples/ExampleS3DistCpWorkflowSpec.scala
@@ -45,7 +45,7 @@ class ExampleS3DistCpWorkflowSpec extends WordSpec {
       val mapReduceClusterShouldBe =
         ("id" -> mapReduceClusterId) ~
         ("name" -> "Cluster with release label") ~
-        ("bootstrapAction" -> List("s3://your-bucket/datapipeline/scripts/deploy-hyperion-emr-env.sh,s3://bucket/org_env.sh")) ~
+        ("bootstrapAction" -> List[String]()) ~
         ("masterInstanceType" -> "m3.xlarge") ~
         ("coreInstanceType" -> "m3.xlarge") ~
         ("coreInstanceCount" -> "2") ~

--- a/examples/src/test/scala/com/krux/hyperion/examples/ExampleSparkSpec.scala
+++ b/examples/src/test/scala/com/krux/hyperion/examples/ExampleSparkSpec.scala
@@ -68,8 +68,8 @@ class ExampleSparkSpec extends WordSpec {
       val sparkClusterShouldBe =
         ("id" -> sparkClusterId) ~
         ("name" -> sparkClusterId) ~
-        ("bootstrapAction" -> List("s3://support.elasticmapreduce/spark/install-spark,-v,1.1.1.e,-x", "s3://your-bucket/datapipeline/scripts/deploy-hyperion-emr-env.sh,s3://bucket/org_env.sh")) ~
-        ("amiVersion" -> "3.3") ~
+        ("bootstrapAction" -> List[String]()) ~
+        ("amiVersion" -> "4.3") ~
         ("masterInstanceType" -> "m3.xlarge") ~
         ("coreInstanceType" -> "m3.xlarge") ~
         ("coreInstanceCount" -> "2") ~
@@ -80,7 +80,8 @@ class ExampleSparkSpec extends WordSpec {
         ("type" -> "EmrCluster") ~
         ("region" -> "us-east-1") ~
         ("role" -> "DataPipelineDefaultRole") ~
-        ("resourceRole" -> "DataPipelineDefaultResourceRole")
+        ("resourceRole" -> "DataPipelineDefaultResourceRole") ~
+        ("applications" -> List("spark"))
       assert(sparkCluster === sparkClusterShouldBe)
 
       val filterActivity = objectsField(5)


### PR DESCRIPTION
… EMR4.3.

    Changes to be committed:

    modified:   core/src/main/scala/com/krux/hyperion/resource/SparkCluster.scala
    Changes are minimal and they involve just overriding the standardBootstrapAction to an empty sequence and adding "spark" to the applications sequence. Both these changes are necessary because the new way of running Spark on EMR4.0+ does not require any bootstrap actions.

    modified:   contrib/activity/definition/src/test/resources/example.conf
    modified:   core/src/test/resources/example.conf
    modified:   examples/src/main/resources/example.conf
    Removed uneccesary entries like spark.version and added release label for emr4.3

    modified:   examples/src/test/scala/com/krux/hyperion/examples/ExampleMapReduceSpec.scala
    modified:   examples/src/test/scala/com/krux/hyperion/examples/ExampleS3DistCpWorkflowSpec.scala
    modified:   examples/src/test/scala/com/krux/hyperion/examples/ExampleSparkSpec.scala
    Fixed the spec to reflect above changes.