### PR TITLE
Adding support for maxActiveInstances optional field for activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.3.0 - 2016-05-17
+##Added
+- [#397](https://github.com/krux/hyperion/issues/397) - Ability to set maxActiveINstances optional field for activities
+
 ## 3.2.14 - 2016-05-12
 ### Fixed
 - [#394](https://github.com/krux/hyperion/issues/394) - Allow using both s3 and hdfs URIs in S3DistCpActivity

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,3 +1,4 @@
+Gregory Titievsky (gtitievsky)
 Lee Baker (bakerlee)
 Arijit Dey (arijitdey)
 Anton Winter (antonwinter)

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "3.2.14"
+val hyperionVersion = "3.3.0"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.7"
 val awsSdkVersion   = "1.10.43"

--- a/contrib/activity/definition/src/main/scala/com/krux/hyperion/activity/RedshiftUnloadActivity.scala
+++ b/contrib/activity/definition/src/main/scala/com/krux/hyperion/activity/RedshiftUnloadActivity.scala
@@ -124,7 +124,8 @@ case class RedshiftUnloadActivity private (
     lateAfterTimeout = lateAfterTimeout.map(_.serialize),
     maximumRetries = maximumRetries.map(_.serialize),
     retryDelay = retryDelay.map(_.serialize),
-    failureAndRerunMode = failureAndRerunMode.map(_.serialize)
+    failureAndRerunMode = failureAndRerunMode.map(_.serialize),
+    maxActiveInstances = maxActiveInstances.map(_.serialize)
   )
 
 }

--- a/contrib/activity/definition/src/main/scala/com/krux/hyperion/activity/S3DistCpActivity.scala
+++ b/contrib/activity/definition/src/main/scala/com/krux/hyperion/activity/S3DistCpActivity.scala
@@ -211,7 +211,8 @@ case class S3DistCpActivity[A <: EmrCluster] private (
     lateAfterTimeout = lateAfterTimeout.map(_.serialize),
     maximumRetries = maximumRetries.map(_.serialize),
     retryDelay = retryDelay.map(_.serialize),
-    failureAndRerunMode = failureAndRerunMode.map(_.serialize)
+    failureAndRerunMode = failureAndRerunMode.map(_.serialize),
+    maxActiveInstances = maxActiveInstances.map(_.serialize)
   )
 
 }

--- a/core/src/main/scala/com/krux/hyperion/activity/ActivityFields.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/ActivityFields.scala
@@ -16,5 +16,6 @@ case class ActivityFields[A <: ResourceObject](
   attemptTimeout: Option[HDuration] = None,
   lateAfterTimeout: Option[HDuration] = None,
   retryDelay: Option[HDuration] = None,
-  failureAndRerunMode: Option[FailureAndRerunMode] = None
+  failureAndRerunMode: Option[FailureAndRerunMode] = None,
+  maxActiveInstances: Option[HInt] = None
 )

--- a/core/src/main/scala/com/krux/hyperion/activity/BaseShellCommandActivity.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/BaseShellCommandActivity.scala
@@ -36,7 +36,7 @@ trait BaseShellCommandActivity extends PipelineActivity[Ec2Resource] {
 
   override def objects = input ++ output ++ super.objects
 
-  def serialize = AdpShellCommandActivity(
+  def serialize = new AdpShellCommandActivity(
     id = id,
     name = name,
     command = script.content.map(_.serialize),
@@ -58,7 +58,8 @@ trait BaseShellCommandActivity extends PipelineActivity[Ec2Resource] {
     lateAfterTimeout = lateAfterTimeout.map(_.serialize),
     maximumRetries = maximumRetries.map(_.serialize),
     retryDelay = retryDelay.map(_.serialize),
-    failureAndRerunMode = failureAndRerunMode.map(_.serialize)
+    failureAndRerunMode = failureAndRerunMode.map(_.serialize),
+    maxActiveInstances = maxActiveInstances.map(_.serialize)
   )
 
 }

--- a/core/src/main/scala/com/krux/hyperion/activity/CopyActivity.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/CopyActivity.scala
@@ -49,7 +49,8 @@ case class CopyActivity private (
     lateAfterTimeout = lateAfterTimeout.map(_.serialize),
     maximumRetries = maximumRetries.map(_.serialize),
     retryDelay = retryDelay.map(_.serialize),
-    failureAndRerunMode = failureAndRerunMode.map(_.serialize)
+    failureAndRerunMode = failureAndRerunMode.map(_.serialize),
+    maxActiveInstances = maxActiveInstances.map(_.serialize)
   )
 }
 

--- a/core/src/main/scala/com/krux/hyperion/activity/HadoopActivity.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/HadoopActivity.scala
@@ -39,7 +39,7 @@ case class HadoopActivity[A <: EmrCluster] private (
 
   override def objects = inputs ++ outputs ++ super.objects
 
-  lazy val serialize = AdpHadoopActivity(
+  lazy val serialize = new AdpHadoopActivity(
     id = id,
     name = name,
     jarUri = jarUri.serialize,
@@ -61,7 +61,8 @@ case class HadoopActivity[A <: EmrCluster] private (
     lateAfterTimeout = lateAfterTimeout.map(_.serialize),
     maximumRetries = maximumRetries.map(_.serialize),
     retryDelay = retryDelay.map(_.serialize),
-    failureAndRerunMode = failureAndRerunMode.map(_.serialize)
+    failureAndRerunMode = failureAndRerunMode.map(_.serialize),
+    maxActiveInstances = maxActiveInstances.map(_.serialize)
   )
 
 }

--- a/core/src/main/scala/com/krux/hyperion/activity/HiveActivity.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/HiveActivity.scala
@@ -62,7 +62,8 @@ case class HiveActivity[A <: EmrCluster] private (
     lateAfterTimeout = lateAfterTimeout.map(_.serialize),
     maximumRetries = maximumRetries.map(_.serialize),
     retryDelay = retryDelay.map(_.serialize),
-    failureAndRerunMode = failureAndRerunMode.map(_.serialize)
+    failureAndRerunMode = failureAndRerunMode.map(_.serialize),
+    maxActiveInstances = maxActiveInstances.map(_.serialize)
   )
 }
 

--- a/core/src/main/scala/com/krux/hyperion/activity/HiveCopyActivity.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/HiveCopyActivity.scala
@@ -55,7 +55,8 @@ case class HiveCopyActivity[A <: EmrCluster] private (
     lateAfterTimeout = lateAfterTimeout.map(_.serialize),
     maximumRetries = maximumRetries.map(_.serialize),
     retryDelay = retryDelay.map(_.serialize),
-    failureAndRerunMode = failureAndRerunMode.map(_.serialize)
+    failureAndRerunMode = failureAndRerunMode.map(_.serialize),
+    maxActiveInstances = maxActiveInstances.map(_.serialize)
   )
 }
 

--- a/core/src/main/scala/com/krux/hyperion/activity/MapReduceActivity.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/MapReduceActivity.scala
@@ -54,7 +54,8 @@ case class MapReduceActivity[A <: EmrCluster] private (
     lateAfterTimeout = lateAfterTimeout.map(_.serialize),
     maximumRetries = maximumRetries.map(_.serialize),
     retryDelay = retryDelay.map(_.serialize),
-    failureAndRerunMode = failureAndRerunMode.map(_.serialize)
+    failureAndRerunMode = failureAndRerunMode.map(_.serialize),
+    maxActiveInstances = maxActiveInstances.map(_.serialize)
   )
 
 }

--- a/core/src/main/scala/com/krux/hyperion/activity/PigActivity.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/PigActivity.scala
@@ -61,7 +61,8 @@ case class PigActivity[A <: EmrCluster] private (
     lateAfterTimeout = lateAfterTimeout.map(_.serialize),
     maximumRetries = maximumRetries.map(_.serialize),
     retryDelay = retryDelay.map(_.serialize),
-    failureAndRerunMode = failureAndRerunMode.map(_.serialize)
+    failureAndRerunMode = failureAndRerunMode.map(_.serialize),
+    maxActiveInstances = maxActiveInstances.map(_.serialize)
   )
 }
 

--- a/core/src/main/scala/com/krux/hyperion/activity/PipelineActivity.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/PipelineActivity.scala
@@ -67,6 +67,11 @@ trait PipelineActivity[A <: ResourceObject] extends NamedPipelineObject {
     activityFields.copy(failureAndRerunMode = Option(mode))
   )
 
+  def maxActiveInstances = activityFields.maxActiveInstances
+  def withMaxActiveInstances(activeInstances: HInt): Self = updateActivityFields(
+    activityFields.copy(maxActiveInstances = Option(activeInstances))
+  )
+
   def objects: Iterable[PipelineObject] = runsOn.toSeq ++ dependsOn ++
     activityFields.onFailAlarms ++
     activityFields.onSuccessAlarms ++

--- a/core/src/main/scala/com/krux/hyperion/activity/RedshiftCopyActivity.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/RedshiftCopyActivity.scala
@@ -69,7 +69,8 @@ case class RedshiftCopyActivity private (
     lateAfterTimeout = lateAfterTimeout.map(_.serialize),
     maximumRetries = maximumRetries.map(_.serialize),
     retryDelay = retryDelay.map(_.serialize),
-    failureAndRerunMode = failureAndRerunMode.map(_.serialize)
+    failureAndRerunMode = failureAndRerunMode.map(_.serialize),
+    maxActiveInstances = maxActiveInstances.map(_.serialize)
   )
 
 }

--- a/core/src/main/scala/com/krux/hyperion/activity/SparkActivity.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/SparkActivity.scala
@@ -52,7 +52,8 @@ case class SparkActivity private (
     lateAfterTimeout = lateAfterTimeout.map(_.serialize),
     maximumRetries = maximumRetries.map(_.serialize),
     retryDelay = retryDelay.map(_.serialize),
-    failureAndRerunMode = failureAndRerunMode.map(_.serialize)
+    failureAndRerunMode = failureAndRerunMode.map(_.serialize),
+    maxActiveInstances = maxActiveInstances.map(_.serialize)
   )
 }
 

--- a/core/src/main/scala/com/krux/hyperion/activity/SparkTaskActivity.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/SparkTaskActivity.scala
@@ -59,7 +59,7 @@ case class SparkTaskActivity private (
 
   private def sparkSettings: Seq[HString] = sparkOptions ++ sparkConfig.flatMap { case (k, v) => Seq[HString]("--conf", s"$k=$v") }
 
-  lazy val serialize = AdpHadoopActivity(
+  lazy val serialize = new AdpHadoopActivity(
     id = id,
     name = name,
     jarUri = scriptRunner.serialize,
@@ -81,7 +81,8 @@ case class SparkTaskActivity private (
     lateAfterTimeout = lateAfterTimeout.map(_.serialize),
     maximumRetries = maximumRetries.map(_.serialize),
     retryDelay = retryDelay.map(_.serialize),
-    failureAndRerunMode = failureAndRerunMode.map(_.serialize)
+    failureAndRerunMode = failureAndRerunMode.map(_.serialize),
+    maxActiveInstances = maxActiveInstances.map(_.serialize)
   )
 
 }

--- a/core/src/main/scala/com/krux/hyperion/activity/SqlActivity.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/SqlActivity.scala
@@ -49,7 +49,8 @@ case class SqlActivity private (
     lateAfterTimeout = lateAfterTimeout.map(_.serialize),
     maximumRetries = maximumRetries.map(_.serialize),
     retryDelay = retryDelay.map(_.serialize),
-    failureAndRerunMode = failureAndRerunMode.map(_.serialize)
+    failureAndRerunMode = failureAndRerunMode.map(_.serialize),
+    maxActiveInstances = maxActiveInstances.map(_.serialize)
   )
 }
 

--- a/core/src/main/scala/com/krux/hyperion/aws/AdpActivities.scala
+++ b/core/src/main/scala/com/krux/hyperion/aws/AdpActivities.scala
@@ -104,6 +104,10 @@ trait AdpActivity extends AdpDataPipelineObject {
    */
   def failureAndRerunMode: Option[String]
 
+  /**
+   *The maximum number of concurrent active instances of a component. Re-runs do not count toward the number of active instances.
+   */
+  def maxActiveInstances: Option[String]
 }
 
 /**
@@ -132,7 +136,8 @@ case class AdpCopyActivity (
   lateAfterTimeout: Option[String],
   maximumRetries: Option[String],
   retryDelay: Option[String],
-  failureAndRerunMode: Option[String]
+  failureAndRerunMode: Option[String],
+  maxActiveInstances: Option[String]
 ) extends AdpActivity {
 
   val `type` = "CopyActivity"
@@ -177,7 +182,8 @@ case class AdpRedshiftCopyActivity (
   lateAfterTimeout: Option[String],
   maximumRetries: Option[String],
   retryDelay: Option[String],
-  failureAndRerunMode: Option[String]
+  failureAndRerunMode: Option[String],
+  maxActiveInstances: Option[String]
 ) extends AdpActivity {
 
   val `type` = "RedshiftCopyActivity"
@@ -196,8 +202,6 @@ case class AdpRedshiftCopyActivity (
  *   up to 255, add multiple preStepCommand fields.
  * @param postStepCommand Shell scripts to be run after all steps are finished. To specify multiple
  *   scripts, up to 255, add multiple postStepCommand fields.
- * @param actionOnResourceFailure Action for the EmrCluster to take when it fails.  String: retryall (retry all inputs) or retrynone (retry nothing)
- * @param actionOnTaskFailure Action for the activity/task to take when its associated EmrCluster fails.  String: continue (do not terminate the cluster) or terminate
  * @param runsOn The Amazon EMR cluster to run this cluster.
  * @param step One or more steps for the cluster to run. To specify multiple steps, up to 255, add
  *   multiple step fields. Use comma-separated arguments after the JAR name; for example,
@@ -222,36 +226,38 @@ case class AdpEmrActivity (
   lateAfterTimeout: Option[String],
   maximumRetries: Option[String],
   retryDelay: Option[String],
-  failureAndRerunMode: Option[String]
+  failureAndRerunMode: Option[String],
+  maxActiveInstances: Option[String]
 ) extends AdpActivity {
 
   val `type` = "EmrActivity"
 
 }
 
-case class AdpHadoopActivity (
-  id: String,
-  name: Option[String],
-  jarUri: String,
-  mainClass: Option[String],
-  argument: Option[Seq[String]],
-  hadoopQueue: Option[String],
-  preActivityTaskConfig: Option[AdpRef[AdpShellScriptConfig]],
-  postActivityTaskConfig: Option[AdpRef[AdpShellScriptConfig]],
-  input: Option[Seq[AdpRef[AdpDataNode]]],
-  output: Option[Seq[AdpRef[AdpDataNode]]],
-  workerGroup: Option[String],
-  runsOn: Option[AdpRef[AdpEmrCluster]],
-  dependsOn: Option[Seq[AdpRef[AdpActivity]]],
-  precondition: Option[Seq[AdpRef[AdpPrecondition]]],
-  onFail: Option[Seq[AdpRef[AdpSnsAlarm]]],
-  onSuccess: Option[Seq[AdpRef[AdpSnsAlarm]]],
-  onLateAction: Option[Seq[AdpRef[AdpSnsAlarm]]],
-  attemptTimeout: Option[String],
-  lateAfterTimeout: Option[String],
-  maximumRetries: Option[String],
-  retryDelay: Option[String],
-  failureAndRerunMode: Option[String]
+class AdpHadoopActivity (
+  val id: String,
+  val name: Option[String],
+  val jarUri: String,
+  val mainClass: Option[String],
+  val argument: Option[Seq[String]],
+  val hadoopQueue: Option[String],
+  val preActivityTaskConfig: Option[AdpRef[AdpShellScriptConfig]],
+  val postActivityTaskConfig: Option[AdpRef[AdpShellScriptConfig]],
+  val input: Option[Seq[AdpRef[AdpDataNode]]],
+  val output: Option[Seq[AdpRef[AdpDataNode]]],
+  val workerGroup: Option[String],
+  val runsOn: Option[AdpRef[AdpEmrCluster]],
+  val dependsOn: Option[Seq[AdpRef[AdpActivity]]],
+  val precondition: Option[Seq[AdpRef[AdpPrecondition]]],
+  val onFail: Option[Seq[AdpRef[AdpSnsAlarm]]],
+  val onSuccess: Option[Seq[AdpRef[AdpSnsAlarm]]],
+  val onLateAction: Option[Seq[AdpRef[AdpSnsAlarm]]],
+  val attemptTimeout: Option[String],
+  val lateAfterTimeout: Option[String],
+  val maximumRetries: Option[String],
+  val retryDelay: Option[String],
+  val failureAndRerunMode: Option[String],
+  val maxActiveInstances: Option[String]
   // XXX - no evidence this is supported actionOnResourceFailure: Option[String],
   // XXX - no evidence this is supported actionOnTaskFailure: Option[String]
 ) extends AdpActivity {
@@ -302,7 +308,8 @@ class AdpHiveActivity (
   val lateAfterTimeout: Option[String],
   val maximumRetries: Option[String],
   val retryDelay: Option[String],
-  val failureAndRerunMode: Option[String]
+  val failureAndRerunMode: Option[String],
+  val maxActiveInstances: Option[String]
 ) extends AdpActivity {
 
   val `type` = "HiveActivity"
@@ -338,7 +345,8 @@ case class AdpHiveCopyActivity (
   lateAfterTimeout: Option[String],
   maximumRetries: Option[String],
   retryDelay: Option[String],
-  failureAndRerunMode: Option[String]
+  failureAndRerunMode: Option[String],
+  maxActiveInstances: Option[String]
 ) extends AdpActivity {
 
   val `type` = "HiveCopyActivity"
@@ -383,7 +391,8 @@ class AdpPigActivity (
   val lateAfterTimeout: Option[String],
   val maximumRetries: Option[String],
   val retryDelay: Option[String],
-  val failureAndRerunMode: Option[String]
+  val failureAndRerunMode: Option[String],
+  val maxActiveInstances: Option[String]
 ) extends AdpActivity {
 
   val `type` = "PigActivity"
@@ -423,7 +432,8 @@ case class AdpSqlActivity (
   lateAfterTimeout: Option[String],
   maximumRetries: Option[String],
   retryDelay: Option[String],
-  failureAndRerunMode: Option[String]
+  failureAndRerunMode: Option[String],
+  maxActiveInstances: Option[String]
 ) extends AdpActivity {
 
   val `type` = "SqlActivity"
@@ -443,29 +453,30 @@ case class AdpSqlActivity (
  * @param stderr The path that receives redirected system error messages from the command. If you use the runsOn field, this must be an Amazon S3 path because of the transitory nature of the resource running your activity. However if you specify the workerGroup field, a local file path is permitted.
  * @param stdout The Amazon S3 path that receives redirected output from the command. If you use the runsOn field, this must be an Amazon S3 path because of the transitory nature of the resource running your activity. However if you specify the workerGroup field, a local file path is permitted.
  */
-case class AdpShellCommandActivity (
-  id: String,
-  name: Option[String],
-  command: Option[String],
-  scriptUri: Option[String],
-  scriptArgument: Option[Seq[String]],
-  stdout: Option[String],
-  stderr: Option[String],
-  stage: Option[String],
-  input: Option[Seq[AdpRef[AdpDataNode]]],
-  output: Option[Seq[AdpRef[AdpDataNode]]],
-  workerGroup: Option[String],
-  runsOn: Option[AdpRef[AdpEc2Resource]],
-  dependsOn: Option[Seq[AdpRef[AdpActivity]]],
-  precondition: Option[Seq[AdpRef[AdpPrecondition]]],
-  onFail: Option[Seq[AdpRef[AdpSnsAlarm]]],
-  onSuccess: Option[Seq[AdpRef[AdpSnsAlarm]]],
-  onLateAction: Option[Seq[AdpRef[AdpSnsAlarm]]],
-  attemptTimeout: Option[String],
-  lateAfterTimeout: Option[String],
-  maximumRetries: Option[String],
-  retryDelay: Option[String],
-  failureAndRerunMode: Option[String]
+class AdpShellCommandActivity (
+  val id: String,
+  val name: Option[String],
+  val command: Option[String],
+  val scriptUri: Option[String],
+  val scriptArgument: Option[Seq[String]],
+  val stdout: Option[String],
+  val stderr: Option[String],
+  val stage: Option[String],
+  val input: Option[Seq[AdpRef[AdpDataNode]]],
+  val output: Option[Seq[AdpRef[AdpDataNode]]],
+  val workerGroup: Option[String],
+  val runsOn: Option[AdpRef[AdpEc2Resource]],
+  val dependsOn: Option[Seq[AdpRef[AdpActivity]]],
+  val precondition: Option[Seq[AdpRef[AdpPrecondition]]],
+  val onFail: Option[Seq[AdpRef[AdpSnsAlarm]]],
+  val onSuccess: Option[Seq[AdpRef[AdpSnsAlarm]]],
+  val onLateAction: Option[Seq[AdpRef[AdpSnsAlarm]]],
+  val attemptTimeout: Option[String],
+  val lateAfterTimeout: Option[String],
+  val maximumRetries: Option[String],
+  val retryDelay: Option[String],
+  val failureAndRerunMode: Option[String],
+  val maxActiveInstances: Option[String]
 ) extends AdpActivity {
 
   val `type` = "ShellCommandActivity"

--- a/core/src/test/scala/com/krux/hyperion/aws/AdpActivitiesSpec.scala
+++ b/core/src/test/scala/com/krux/hyperion/aws/AdpActivitiesSpec.scala
@@ -22,7 +22,8 @@ class AdpActivitiesSpec extends WordSpec {
         lateAfterTimeout = None,
         maximumRetries = None,
         retryDelay = None,
-        failureAndRerunMode = None
+        failureAndRerunMode = None,
+        maxActiveInstances = None
       )
       val objShouldBe = ("id" -> "GenericCopyActivity") ~
         ("input" -> ("ref" -> "MyS3DataNode")) ~
@@ -55,7 +56,8 @@ class AdpActivitiesSpec extends WordSpec {
         lateAfterTimeout = None,
         maximumRetries = None,
         retryDelay = None,
-        failureAndRerunMode = None
+        failureAndRerunMode = None,
+        maxActiveInstances = None
       )
       val objShouldBe = ("id" -> "S3ToRedshiftCopyActivity") ~
         ("input" -> ("ref" -> "MyS3DataNode")) ~
@@ -92,7 +94,8 @@ class AdpActivitiesSpec extends WordSpec {
         lateAfterTimeout = None,
         maximumRetries = None,
         retryDelay = None,
-        failureAndRerunMode = None
+        failureAndRerunMode = None,
+        maxActiveInstances = None
       )
       val objShouldBe = ("id" -> "MyEmrActivity") ~
         ("input" ->  Seq(("ref" -> "MyS3Input"))) ~
@@ -133,7 +136,8 @@ class AdpActivitiesSpec extends WordSpec {
         lateAfterTimeout = None,
         maximumRetries = None,
         retryDelay = None,
-        failureAndRerunMode = None
+        failureAndRerunMode = None,
+        maxActiveInstances = None
       )
       val objShouldBe = ("id" -> "HiveActivity") ~
         ("hiveScript" -> "SELECT * FROM TABLE") ~
@@ -168,7 +172,8 @@ class AdpActivitiesSpec extends WordSpec {
         lateAfterTimeout = None,
         maximumRetries = None,
         retryDelay = None,
-        failureAndRerunMode = None
+        failureAndRerunMode = None,
+        maxActiveInstances = None
       )
       val objShouldBe = ("id" -> "HiveCopyActivity") ~
         ("filterSql" -> "SELECT * FROM TABLE") ~
@@ -205,7 +210,8 @@ class AdpActivitiesSpec extends WordSpec {
         lateAfterTimeout = None,
         maximumRetries = None,
         retryDelay = None,
-        failureAndRerunMode = None
+        failureAndRerunMode = None,
+        maxActiveInstances = None
       )
       val objShouldBe = ("id" -> "PigActivity") ~
         ("script" -> "SELECT * FROM TABLE") ~
@@ -239,7 +245,8 @@ class AdpActivitiesSpec extends WordSpec {
         lateAfterTimeout = None,
         maximumRetries = None,
         retryDelay = None,
-        failureAndRerunMode = None
+        failureAndRerunMode = None,
+        maxActiveInstances = None
       )
       val objShouldBe = ("id" -> "SqlActivity") ~
         ("database" -> ("ref" -> "MyDatabase")) ~
@@ -253,7 +260,7 @@ class AdpActivitiesSpec extends WordSpec {
 
   "AdpShellCommandActivity" should {
     "converts to json" in {
-      val testObj = AdpShellCommandActivity(
+      val testObj = new AdpShellCommandActivity(
         id = "ShellCommandActivity",
         name = None,
         command = Option("rm -rf /"),
@@ -275,7 +282,8 @@ class AdpActivitiesSpec extends WordSpec {
         lateAfterTimeout = None,
         maximumRetries = None,
         retryDelay = None,
-        failureAndRerunMode = None
+        failureAndRerunMode = None,
+        maxActiveInstances = None
       )
       val objShouldBe = ("id" -> "ShellCommandActivity") ~
         ("command" -> "rm -rf /") ~


### PR DESCRIPTION
all of the activities in http://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-object-activities.html contain maxActiveInstances field. Adding it to be able to create a pipeline with that field.