### PR TITLE
(Fixes #353) Nicer handling for reducing iterable workflow expressions and empty workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.8.0 - 2016-12-11
+### Added
+- [#353](https://github.com/krux/hyperion/issues/353) - Enable .reduceLeft(_ ~> _) on a list of pipeline activities
+
 ## 4.7.0 - 2016-12-07
 ### Fixed
 - [#477](https://github.com/krux/hyperion/issues/477) - Make `initTimeout` as a optional global configuration

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add Krux Hyperion as a dependency in your `build.sbt` or `Build.scala` as approp
 ```scala
 libraryDependencies ++= Seq(
   // Other dependencies ...
-  "com.krux" %% "hyperion" % "4.7.0"
+  "com.krux" %% "hyperion" % "4.8.0"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "4.7.0"
+val hyperionVersion = "4.8.0"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.8"
 val awsSdkVersion   = "1.10.43"

--- a/core/src/main/scala/com/krux/hyperion/workflow/WorkflowExpression.scala
+++ b/core/src/main/scala/com/krux/hyperion/workflow/WorkflowExpression.scala
@@ -64,4 +64,6 @@ case class WorkflowArrowExpression(left: WorkflowExpression, right: WorkflowExpr
 
 case class WorkflowPlusExpression(left: WorkflowExpression, right: WorkflowExpression) extends WorkflowExpression
 
-object WorkflowExpression extends WorkflowExpressionImplicits
+object WorkflowExpression extends WorkflowExpressionImplicits {
+  def empty: WorkflowExpression = WorkflowNoActivityExpression
+}

--- a/core/src/main/scala/com/krux/hyperion/workflow/WorkflowExpressionImplicits.scala
+++ b/core/src/main/scala/com/krux/hyperion/workflow/WorkflowExpressionImplicits.scala
@@ -8,13 +8,18 @@ import com.krux.hyperion.resource.ResourceObject
 trait WorkflowExpressionImplicits {
 
   implicit def workflowIterable2WorkflowExpression(activities: Iterable[WorkflowExpression]): WorkflowExpression =
-    activities.reduceLeft(_ + _)
+    activities.foldLeft(WorkflowExpression.empty)(_ + _)
 
   implicit def activityIterable2WorkflowExpression(activities: Iterable[PipelineActivity[_ <: ResourceObject]]): WorkflowExpression =
-    activities.map(activity2WorkflowExpression).reduceLeft(_ + _)
+    activities.foldLeft(WorkflowExpression.empty)(_ + _)
 
   implicit def activity2WorkflowExpression(activity: PipelineActivity[_ <: ResourceObject]): WorkflowExpression =
     WorkflowActivityExpression(activity)
+
+  implicit class activityIterable2WorkflowExpressionOps(activities: Iterable[PipelineActivity[_ <: ResourceObject]]) {
+    def toWorkflowExpression(reducer: (WorkflowExpression, PipelineActivity[_ <: ResourceObject]) => WorkflowExpression = _ + _): WorkflowExpression =
+      activities.foldLeft(WorkflowExpression.empty)(reducer)
+  }
 
   implicit class activityWorkflowExpressionOps(activity: PipelineActivity[_ <: ResourceObject]) {
     def toWorkflowExpression: WorkflowExpression = activity

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.12


### PR DESCRIPTION
Current handling of an `Iterable` of `WorkflowExpression` or `PipelineActivity` fails on `reduceLeft` given empty `Iterable`.  Also, handling of `foldLeft` with a start of `WorkflowNoActivityExpression` is cumbersome.  This change makes this common use case cleaner.