### PR TITLE
(Fixes #517) Fix header option for SplitMergeFilesActivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.14.1 - 2017-11-28
+### Fixed
+- [#517](https://github.com/krux/hyperion/issues/517) - Fixed header option when 1 input file is used in SplitMergeFilesActivity
+
 ## 4.14.0 - 2017-11-25
 ### Changed
 - [#507] (https://github.com/krux/hyperion/issues/507) - Support STS token when the environment variable is set

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "4.14.0"
+val hyperionVersion = "4.14.1"
 val scala210Version = "2.10.6"
 val scala211Version = "2.11.8"
 val awsSdkVersion   = "1.10.75"

--- a/contrib/activity/file/src/main/scala/com/krux/hyperion/contrib/activity/file/FileRepartitioner.scala
+++ b/contrib/activity/file/src/main/scala/com/krux/hyperion/contrib/activity/file/FileRepartitioner.scala
@@ -8,7 +8,7 @@ case class FileRepartitioner(options: Options) {
   def repartition(): Boolean = moveFiles(nameFiles(split(merge())))
 
   private def merge(): File = options.inputs match {
-    case Seq(one) => one
+    case Seq(one) if options.numberOfFiles != Some(1) || options.header.isEmpty => one
 
     case files =>
       val destination: File = File.createTempFile("merge-", if (options.compressed) ".gz" else ".tmp", options.temporaryDirectory.get)


### PR DESCRIPTION
Currently, if there is only 1 input file and partitions are not required the
header option is ignored.
This change fixes it so under these circumstances the header will be added to
the output file. It also retains the original functionality of just moving
the input file to the output location if the header is not used.