### PR TITLE
(Fixes #554) add parquet and orc redshift copy options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 5.1.3 - 2018-09-04
+
+## Changed
+[#554](https://github.com/krux/hyperion/issues/550) - Handle Parquet and ORC formats in Redshift Copy
+
 ## 5.1.2 - 2018-07-06
 
 ## Changed

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "5.1.2"
+val hyperionVersion = "5.1.3"
 val scala211Version = "2.11.12"
 val scala212Version = "2.12.6"
 val awsSdkVersion   = "[1.11.238, 1.12.0)"

--- a/core/src/main/scala/com/krux/hyperion/activity/RedshiftCopyOption.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/RedshiftCopyOption.scala
@@ -58,4 +58,8 @@ object RedshiftCopyOption {
 
   def avro: RedshiftCopyOption = avro("auto")
 
+  def parquet = RedshiftCopyOption(Seq("FORMAT", "PARQUET"))
+
+  def orc = RedshiftCopyOption(Seq("FORMAT", "ORC"))
+
 }


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2018/06/amazon-redshift-can-now-copy-from-parquet-and-orc-file-formats/