### PR TITLE
Print pipeline console URL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "5.4.1"
+val hyperionVersion = "5.4.2"
 val scala211Version = "2.11.12"
 val scala212Version = "2.12.8"
 val awsSdkVersion   = "[1.11.238, 1.12.0)"

--- a/core/src/main/scala/com/krux/hyperion/cli/CreateAction.scala
+++ b/core/src/main/scala/com/krux/hyperion/cli/CreateAction.scala
@@ -9,6 +9,6 @@ private[hyperion] case object CreateAction extends AwsAction {
       client.createPipelines(options.force, options.checkExistence).flatMap(_.activatePipelines())
     else
       client.createPipelines(options.force, options.checkExistence)
-  }.isDefined
+  }.flatMap(_.printConsoleUrl()).isDefined
 
 }

--- a/core/src/main/scala/com/krux/hyperion/client/AwsClientForDef.scala
+++ b/core/src/main/scala/com/krux/hyperion/client/AwsClientForDef.scala
@@ -18,7 +18,7 @@ case class AwsClientForDef(
   }
 
   def forName(): Option[AwsClientForName] = Option(
-    AwsClientForName(client, pipelineDef.pipelineName, maxRetry, pipelineDef.nameKeySeparator)
+    AwsClientForName(client, pipelineDef.hc.region, pipelineDef.pipelineName, maxRetry, pipelineDef.nameKeySeparator)
   )
 
   /**
@@ -38,7 +38,7 @@ case class AwsClientForDef(
 
     val existingPipelines =
       if (checkExistence)
-        AwsClientForName(client, pipelineDef.pipelineName, maxRetry, pipelineDef.nameKeySeparator)
+        AwsClientForName(client, pipelineDef.hc.region, pipelineDef.pipelineName, maxRetry, pipelineDef.nameKeySeparator)
           .pipelineIdNames
       else
         Map.empty[String, String]
@@ -51,7 +51,7 @@ case class AwsClientForDef(
 
       if (force) {
         log.info("Delete the existing pipeline")
-        AwsClientForId(client, existingPipelines.keySet, maxRetry).deletePipelines()
+        AwsClientForId(client, pipelineDef.hc.region, existingPipelines.keySet, maxRetry).deletePipelines()
         prepareForCreation(force, checkExistence)
       } else {
         log.error("Use --force to force pipeline creation")

--- a/core/src/main/scala/com/krux/hyperion/client/AwsClientForId.scala
+++ b/core/src/main/scala/com/krux/hyperion/client/AwsClientForId.scala
@@ -7,6 +7,7 @@ import com.amazonaws.services.datapipeline.model.{DeactivatePipelineRequest,
 
 case class AwsClientForId(
   client: DataPipeline,
+  region: String,
   pipelineIds: Set[String],
   override val maxRetry: Int
 ) extends AwsClient {
@@ -38,6 +39,13 @@ case class AwsClientForId(
         .retry()
     }
     Option(this)
+  }
+
+  def printConsoleUrl(): Option[Unit] = {
+    pipelineIds.foreach { id =>
+      log.info(s"https://console.aws.amazon.com/datapipeline/home?region=$region#ExecutionDetailsPlace:pipelineId=$id&show=latest")
+    }
+    Option(Unit)
   }
 
 }

--- a/core/src/main/scala/com/krux/hyperion/client/AwsClientForName.scala
+++ b/core/src/main/scala/com/krux/hyperion/client/AwsClientForName.scala
@@ -11,6 +11,7 @@ import com.krux.hyperion.DataPipelineDefGroup
 
 case class AwsClientForName(
   client: DataPipeline,
+  region: String,
   pipelineName: String,
   override val maxRetry: Int,
   nameKeySeparator: String = DataPipelineDefGroup.DefaultNameKeySeparator
@@ -65,6 +66,6 @@ case class AwsClientForName(
 
   def forId(): Option[AwsClientForId] =
     if (pipelineIdNames.isEmpty) None
-    else Option(AwsClientForId(client, pipelineIdNames.keySet, maxRetry))
+    else Option(AwsClientForId(client, region, pipelineIdNames.keySet, maxRetry))
 
 }

--- a/core/src/main/scala/com/krux/hyperion/client/UploadPipelineObjectsTrans.scala
+++ b/core/src/main/scala/com/krux/hyperion/client/UploadPipelineObjectsTrans.scala
@@ -62,7 +62,7 @@ case class UploadPipelineObjectsTrans(
       if (putDefinitionResult.getErrored) {
         log.error(s"Failed to upload pipeline definition to pipeline $pipelineId")
         log.error(s"Deleting the just created pipeline $pipelineId")
-        AwsClientForId(client, Set(pipelineId), maxRetry).deletePipelines()
+        AwsClientForId(client, pipelineDef.hc.region, Set(pipelineId), maxRetry).deletePipelines()
         None
       } else if (putDefinitionResult.getValidationErrors.isEmpty
         && putDefinitionResult.getValidationWarnings.isEmpty) {
@@ -77,7 +77,7 @@ case class UploadPipelineObjectsTrans(
       case e: InvalidRequestException =>
         log.error(s"InvalidRequestException (${e.getErrorCode}): ${e.getErrorMessage}")
         log.error("Deleting the just created pipeline")
-        AwsClientForId(client, Set(pipelineId), maxRetry).deletePipelines()
+        AwsClientForId(client, pipelineDef.hc.region, Set(pipelineId), maxRetry).deletePipelines()
         None
     }
 
@@ -85,6 +85,7 @@ case class UploadPipelineObjectsTrans(
 
   def action() = AwsClientForId(
     client,
+    pipelineDef.hc.region,
     keyObjectsMap
       .toStream  // there is no need to keep perform createAndUploadObojects if one failed
       .map { case (key, objects) =>


### PR DESCRIPTION
It is handy to have the pipeline console URL in hyperion output.

Example:

```bash
... (omitted)
[main] INFO com.krux.hyperion.client.AwsClientForId - https://console.aws.amazon.com/datapipeline/home?region=us-west-2#ExecutionDetailsPlace:pipelineId=df-09261901CT5Z5GPNDZQF&show=latest
[success] Total time: 13 s, completed Aug 28, 2019 3:26:10 PM
```