### PR TITLE
Script run-python.sh now expects a requirements.txt file instead of requirements.pip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 5.5.1 - 2019-09-13
+### Changed
+- Script `run-python.sh` now expects a `requirements.txt` file instead of `requirements.pip`.
+
 ## 5.5.0 - 2019-09-10
 ### Changed
 - [#583](https://github.com/krux/hyperion/issues/579) - House keeping updates.

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "5.5.1"
+val hyperionVersion = "5.6.0"
 val scala211Version = "2.11.12"
 val scala212Version = "2.12.9"
 val awsSdkVersion   = "[1.11.238, 1.12.0)"

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "5.5.0"
+val hyperionVersion = "5.5.1"
 val scala211Version = "2.11.12"
 val scala212Version = "2.12.9"
 val awsSdkVersion   = "[1.11.238, 1.12.0)"

--- a/scripts/activities/run-python.sh
+++ b/scripts/activities/run-python.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-# Usage: $0 s3://something.{py,gz} (-r requirements.pip)? (-m module)? (-i index-url)? (--extra-index-url url)? script.py? -- args
+# Usage: $0 s3://something.{py,gz} (-r requirements.txt)? (-m module)? (-i index-url)? (--extra-index-url url)? script.py? -- args
 
 declare -a on_exit_items
 
@@ -23,7 +23,7 @@ set -xe
 PY_REMOTE=${1?Python URL required}; shift
 PY_LOCAL="$(basename ${PY_REMOTE})"
 PY_EXT="${PY_LOCAL##*.}"
-REQUIREMENTS="requirements.pip"
+REQUIREMENTS="requirements.txt"
 WORKING_DIR=$(mktemp -d)
 cd ${WORKING_DIR}
 add_on_exit rm -rf ${WORKING_DIR}


### PR DESCRIPTION
For historical reasons peculiar to Krux, the `run-python.sh` script expected a `requirements.pip` file instead of a standard `requirements.txt` one. This change standardizes on `requirements.txt`.