### PR TITLE
Fix SparkTaskActivity to work with command-runner.jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 5.8.1 - 2019-12-06
+### Fixed
+- [#441](https://github.com/krux/hyperion/issues/441) - Fix SparkTaskActivity to correctly run with the command-runner.jar.
+
 ## 5.8.0 - 2019-11-18
 ### Changed
 - [#341](https://github.com/krux/hyperion/issues/341) - Generate activity dependencies without any transitive dependencies.

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "5.8.0"
+val hyperionVersion = "5.8.1"
 val scala211Version = "2.11.12"
 val scala212Version = "2.12.9"
 val awsSdkVersion   = "[1.11.238, 1.12.0)"

--- a/core/src/main/scala/com/krux/hyperion/activity/package.scala
+++ b/core/src/main/scala/com/krux/hyperion/activity/package.scala
@@ -1,5 +1,7 @@
 package com.krux.hyperion
 
+import java.net.URI
+
 import com.krux.hyperion.common.S3Uri
 import com.krux.hyperion.common.S3Uri._
 
@@ -11,4 +13,5 @@ package object activity {
 
   final val EmrCommandRunner: String = "command-runner.jar"
 
+  final val EmrHadoopJarsDir: URI = URI.create("/var/lib/aws/emr/step-runner/hadoop-jars/")
 }

--- a/core/src/test/scala/com/krux/hyperion/activity/SparkTaskActivitySpec.scala
+++ b/core/src/test/scala/com/krux/hyperion/activity/SparkTaskActivitySpec.scala
@@ -25,7 +25,7 @@ class SparkTaskActivitySpec extends FlatSpec {
   it should "handle command runner" in {
     val cluster = EmrCluster().withApplications(EmrApplication.Spark)
     val activity = SparkTaskActivity.commandRunner("something.jar")(cluster).withMainClass(MainClass)
-    activity.jarUri.shouldBe("command-runner.jar": HString)
+    activity.jarUri.shouldBe("/var/lib/aws/emr/step-runner/hadoop-jars/command-runner.jar": HString)
     activity.command.shouldBe("spark-submit": HString)
   }
 }


### PR DESCRIPTION
We ran into a couple of issues when using `SparkTaskActivity` with the command-runner.

1st issue:  As described here: https://github.com/krux/hyperion/issues/441
Other than EmrStep, HadoopActivity must apparently provide the full path to the jar.

2nd issue: When using a jar in S3, the main class must be provided using the `--class` spark-submit option.
@realstraw I'm not entirely sure how to address this regarding your script runners. Any feedback there?


