### PR TITLE
Correctly serialize the default value of datetime params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 5.7.1 - 2019-11-08
+### Fixed
+[#578](https://github.com/krux/hyperion/issues/578) - Correctly serialize the default value of datetime params.
+
 ## 5.7.0 - 2019-11-07
 ### Changed
 - [#590](https://github.com/krux/hyperion/issues/590) - Hyperion Level support to merge and split files for Bz2 compression format

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "5.7.0"
+val hyperionVersion = "5.7.1"
 val scala211Version = "2.11.12"
 val scala212Version = "2.12.9"
 val awsSdkVersion   = "[1.11.238, 1.12.0)"

--- a/core/src/main/scala/com/krux/hyperion/expression/GenericParameter.scala
+++ b/core/src/main/scala/com/krux/hyperion/expression/GenericParameter.scala
@@ -2,7 +2,8 @@ package com.krux.hyperion.expression
 
 import org.joda.time.{ DateTime, DateTimeZone }
 
-import com.krux.hyperion.common.{HdfsUri, S3Uri}
+import com.krux.hyperion.adt.HDateTime
+import com.krux.hyperion.common.{ HdfsUri, S3Uri }
 import com.krux.hyperion.expression.ParameterType._
 
 /**
@@ -20,11 +21,18 @@ trait GenericParameter[T] {
 
   /**
    * This needs to be implemented as a function (instead of a method) as we need to store it with
-   * the class at the time the implicit parseString for the type is availble (when the parameter
+   * the class at the time the implicit parseString for the type is available (when the parameter
    * instance is created). Since the calling of this function is mainly used when type is not
    * available such as in {{{List[Parameter[_]]}}}.
    */
   def parseString: (String) => T
+
+
+  /**
+   * This must be overwritten if default object serialization doesn't conform with
+   * the expected serialization format for a parameter value T.
+   */
+  def serialize(t: T): String = t.toString
 
   /**
    * Returns the reference expression of the parameter.
@@ -106,6 +114,8 @@ object GenericParameter {
     type Exp = DateTimeExp
 
     val parseString = (stringValue: String) => new DateTime(stringValue, DateTimeZone.UTC)
+
+    override def serialize(t: DateTime): String = (t: HDateTime).serialize
 
     def ref(param: Parameter[DateTime]): Exp = new Exp with Evaluatable[DateTime] {
       def content = param.name

--- a/core/src/main/scala/com/krux/hyperion/expression/Parameter.scala
+++ b/core/src/main/scala/com/krux/hyperion/expression/Parameter.scala
@@ -6,7 +6,7 @@ import org.joda.time.DateTime
 
 import com.krux.hyperion.adt._
 import com.krux.hyperion.aws.AdpParameter
-import com.krux.hyperion.common.{HdfsUri, S3Uri}
+import com.krux.hyperion.common.{ HdfsUri, S3Uri }
 
 /**
  * Defines and builds Parameter and returns the specific type instead of the paraent type.
@@ -73,7 +73,7 @@ sealed abstract class Parameter[T : GenericParameter] extends ParameterBuilder[T
       optional = HBoolean.False.serialize,
       allowedValues = None,
       isArray = HBoolean.False.serialize,
-      `default` = value.map(_.toString)
+      `default` = value.map(env.serialize)
     )
   )
 

--- a/core/src/test/scala/com/krux/hyperion/expression/ParameterSpec.scala
+++ b/core/src/test/scala/com/krux/hyperion/expression/ParameterSpec.scala
@@ -1,0 +1,21 @@
+package com.krux.hyperion.expression
+
+import org.joda.time.DateTime
+import org.scalatest.{ OptionValues, WordSpec }
+
+import com.krux.hyperion.aws.AdpParameter
+
+class ParameterSpec extends WordSpec with OptionValues {
+  "Parameter[DateTime]" should {
+    "be serialized in the correct datetime format" in {
+      implicit val values = new ParameterValues()
+
+      val dateTimeParam = Parameter[DateTime]("datetime", new DateTime("2014-04-02T00:00:00Z"))
+
+      assert(dateTimeParam.serialize.value === AdpParameter(
+        id = "my_datetime",
+        `default` = Some("2014-04-02T00:00:00")
+      ))
+    }
+  }
+}


### PR DESCRIPTION
This fixes the serialization problem of datetime parameter defaults described here:
https://github.com/krux/hyperion/issues/578