### PR TITLE
Correctly generate activity dependencies without any transitive ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 5.8.0 - 2019-11-18
+### Changed
+- [#341](https://github.com/krux/hyperion/issues/341) - Generate activity dependencies without any transitive dependencies.
+
 ## 5.7.2 - 2019-11-08
 ### Changed
 - [#595](https://github.com/krux/hyperion/issues/595) - Not able to import compressionFormat enum in other repository which uses hyperion

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val hyperionVersion = "5.7.2"
+val hyperionVersion = "5.8.0"
 val scala211Version = "2.11.12"
 val scala212Version = "2.12.9"
 val awsSdkVersion   = "[1.11.238, 1.12.0)"

--- a/core/src/main/scala/com/krux/hyperion/workflow/WorkflowExpression.scala
+++ b/core/src/main/scala/com/krux/hyperion/workflow/WorkflowExpression.scala
@@ -4,27 +4,9 @@ import com.krux.hyperion.activity.PipelineActivity
 import com.krux.hyperion.common.PipelineObject
 import com.krux.hyperion.resource.ResourceObject
 
-
 sealed abstract class WorkflowExpression {
 
-  def toActivities: Iterable[PipelineActivity[_ <: ResourceObject]] = {
-
-    def toWorkflowGraph(exp: WorkflowExpression): WorkflowGraph = {
-      exp match {
-        case WorkflowNoActivityExpression =>
-          new WorkflowGraph()
-        case WorkflowActivityExpression(act) =>
-          new WorkflowGraph(act)
-        case WorkflowArrowExpression(left, right) =>
-          toWorkflowGraph(left) ~> toWorkflowGraph(right)
-        case WorkflowPlusExpression(left, right) =>
-          toWorkflowGraph(left) ++ toWorkflowGraph(right)
-      }
-    }
-
-    toWorkflowGraph(this).toActivities
-
-  }
+  def toActivities: Iterable[PipelineActivity[_ <: ResourceObject]] = WorkflowGraph(this).toActivities
 
   def toPipelineObjects: Iterable[PipelineObject] = {
 
@@ -35,7 +17,6 @@ sealed abstract class WorkflowExpression {
     toActivities
       .foldLeft(Map.empty[String, PipelineObject])(flattenPipelineObjects)
       .values
-
   }
 
   def andThen(right: WorkflowExpression): WorkflowExpression = right match {


### PR DESCRIPTION
This addressed issue https://github.com/krux/hyperion/issues/341. 

We've recently ran into Data Pipeline errors caused by the inclusion of transitive dependencies:
```
Errors: [May only specify up to '50' fields per object]
```
Problem is simply that this can quickly explode the number of fields per object.