### PR TITLE
Use json4s native backend instead of jackson

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ val slf4jVersion    = "1.7.25"
 
 val nscalaTimeArtifact      = "com.github.nscala-time" %% "nscala-time"               % "2.18.0"
 val jodaConvertArtifact     = "org.joda"               %  "joda-convert"              % "2.0"    % "provided"
-val json4sJacksonArtifact   = "org.json4s"             %% "json4s-jackson"            % "3.5.3"
+val json4sNativeArtifact    = "org.json4s"             %% "json4s-native"             % "3.5.3"
 val scoptArtifact           = "com.github.scopt"       %% "scopt"                     % "3.7.0"
 val jschArtifact            = "com.jcraft"             %  "jsch"                      % "0.1.54"
 val configArtifact          = "com.typesafe"           %  "config"                    % "1.3.2"
@@ -133,7 +133,7 @@ lazy val core = (project in file("core")).
       awsDatapipelineArtifact,
       awsStsArtifact,
       nscalaTimeArtifact,
-      json4sJacksonArtifact,
+      json4sNativeArtifact,
       scoptArtifact,
       configArtifact,
       slf4jApiArtifact,
@@ -202,7 +202,7 @@ lazy val contribActivityNotification = (project in file("contrib/activity/notifi
     name := "hyperion-notification-activity",
     libraryDependencies ++= Seq(
       scoptArtifact,
-      json4sJacksonArtifact,
+      json4sNativeArtifact,
       awsSnsArtifact,
       awsSqsArtifact,
       smtpArtifact

--- a/contrib/activity/notification/src/main/scala/com/krux/hyperion/contrib/activity/notification/SendFlowdockMessage.scala
+++ b/contrib/activity/notification/src/main/scala/com/krux/hyperion/contrib/activity/notification/SendFlowdockMessage.scala
@@ -3,7 +3,7 @@ package com.krux.hyperion.contrib.activity.notification
 import java.net.{ HttpURLConnection, URL }
 
 import org.json4s.JsonDSL._
-import org.json4s.jackson.JsonMethods._
+import org.json4s.native.JsonMethods._
 import scopt.OptionParser
 
 object SendFlowdockMessage {

--- a/contrib/activity/notification/src/main/scala/com/krux/hyperion/contrib/activity/notification/SendSlackMessage.scala
+++ b/contrib/activity/notification/src/main/scala/com/krux/hyperion/contrib/activity/notification/SendSlackMessage.scala
@@ -3,7 +3,7 @@ package com.krux.hyperion.contrib.activity.notification
 import java.net.{ HttpURLConnection, URL }
 
 import org.json4s.JsonAST.{ JString, JObject }
-import org.json4s.jackson.JsonMethods._
+import org.json4s.native.JsonMethods._
 import scopt.OptionParser
 
 object SendSlackMessage {

--- a/core/src/main/scala/com/krux/hyperion/cli/GenerateAction.scala
+++ b/core/src/main/scala/com/krux/hyperion/cli/GenerateAction.scala
@@ -2,7 +2,7 @@ package com.krux.hyperion.cli
 
 import java.io.PrintStream
 
-import org.json4s.jackson.JsonMethods._
+import org.json4s.native.JsonMethods._
 
 import com.krux.hyperion.DataPipelineDefGroup
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0
+sbt.version=1.3.6


### PR DESCRIPTION
This removes json4s' dependency on jackson from hyperion (aws libraries still use jackson) while using the same json4s API for serialization.

Upgrading sbt version is necessary to prevent `java.lang.OutOfMemoryError: Metaspace`.