### PR TITLE
Capability to run Custom code when the pipeline is started

### DIFF
--- a/core/src/main/scala/com/krux/hyperion/DataPipelineDefGroup.scala
+++ b/core/src/main/scala/com/krux/hyperion/DataPipelineDefGroup.scala
@@ -29,6 +29,14 @@ trait DataPipelineDefGroup
 
   def schedule: Schedule
 
+  def pipelineLifeCycle: PipelineLifeCycle = new PipelineLifeCycle {
+
+    override def startPipeline(id: String, name: String, status: String): Unit = {
+
+    }
+
+  }
+
   /**
    * No delay by default
    */
@@ -78,6 +86,7 @@ object DataPipelineDefGroup {
             dpdg.hc,
             dpdg.nameForKey(key),
             delayedSchedule(dpdg, idx),
+            dpdg.pipelineLifeCycle,
             () => workflow,
             dpdg.tags,
             dpdg.parameters
@@ -101,6 +110,7 @@ object DataPipelineDefGroup {
 
     def toAwsPipelineObjects: Map[WorkflowKey, Seq[AwsPipelineObject]] =
       objects.mapValues(_.map(_.serialize).toList.sortBy(_.id).map(AdpPipelineSerializer(_)))
+
 
     def toJson: JValue =
       ("objects" -> JArray(objects.values.flatten.map(_.serialize).toList.sortBy(_.id).map(AdpJsonSerializer(_)))) ~

--- a/core/src/main/scala/com/krux/hyperion/DataPipelineDefGroupWrapper.scala
+++ b/core/src/main/scala/com/krux/hyperion/DataPipelineDefGroupWrapper.scala
@@ -4,22 +4,24 @@ import com.krux.hyperion.expression.{Duration, Parameter}
 import com.krux.hyperion.workflow.WorkflowExpression
 
 
-case class DataPipelineDefGroupWrapper private (
-  override val hc: HyperionContext,
-  override val pipelineName: String,
-  override val nameKeySeparator: String,
-  schedule: Schedule,
-  override val scheduleDelay: Option[Duration],
-  workflowsFunc: () => Map[WorkflowKey, WorkflowExpression],  // for delayed workfow execution
-  override val tags: Map[String, Option[String]],
-  override val parameters: Iterable[Parameter[_]]
-) extends DataPipelineDefGroup {
+case class DataPipelineDefGroupWrapper private(
+                                                override val hc: HyperionContext,
+                                                override val pipelineName: String,
+                                                override val nameKeySeparator: String,
+                                                schedule: Schedule,
+                                                override val pipelineLifeCycle: PipelineLifeCycle,
+                                                override val scheduleDelay: Option[Duration],
+                                                workflowsFunc: () => Map[WorkflowKey, WorkflowExpression], // for delayed workfow execution
+                                                override val tags: Map[String, Option[String]],
+                                                override val parameters: Iterable[Parameter[_]]
+                                              ) extends DataPipelineDefGroup {
 
   def withName(name: String) = copy(pipelineName = name)
   def withSchedule(schedule: Schedule) = copy(schedule = schedule)
   def withScheduleDelay(scheduleDelay: Option[Duration]) = copy(scheduleDelay = scheduleDelay)
   def withTags(tags: Map[String, Option[String]]) = copy(tags = this.tags ++ tags)
   def withParameters(parameters: Iterable[Parameter[_]]) = copy(parameters = parameters)
+  def withPipelineLifeCycle(pipelineLifeCycle: PipelineLifeCycle) = copy(pipelineLifeCycle = pipelineLifeCycle)
 
   def workflows = workflowsFunc()
 
@@ -33,6 +35,7 @@ object DataPipelineDefGroupWrapper {
       inner.pipelineName,
       inner.nameKeySeparator,
       inner.schedule,
+      inner.pipelineLifeCycle,
       inner.scheduleDelay,
       () => inner.workflows,
       inner.tags,

--- a/core/src/main/scala/com/krux/hyperion/DataPipelineDefWrapper.scala
+++ b/core/src/main/scala/com/krux/hyperion/DataPipelineDefWrapper.scala
@@ -9,16 +9,18 @@ import com.krux.hyperion.workflow.WorkflowExpression
   * in order to override aspects.
   */
 case class DataPipelineDefWrapper private[hyperion] (
-  override val hc: HyperionContext,
-  override val pipelineName: String,
-  schedule: Schedule,
-  workflowFunc: () => WorkflowExpression,  // for delayed workflow execution
-  override val tags: Map[String, Option[String]],
-  override val parameters: Iterable[Parameter[_]]
+                                                      override val hc: HyperionContext,
+                                                      override val pipelineName: String,
+                                                      schedule: Schedule,
+                                                      override val pipelineLifeCycle: PipelineLifeCycle,
+                                                      workflowFunc: () => WorkflowExpression, // for delayed workflow execution
+                                                      override val tags: Map[String, Option[String]],
+                                                      override val parameters: Iterable[Parameter[_]]
 ) extends DataPipelineDef {
 
   def withName(name: String) = copy(pipelineName = name)
   def withSchedule(schedule: Schedule) = copy(schedule = schedule)
+  def withPipelineLifeCycle(pipelineLifeCycle: PipelineLifeCycle) = copy(pipelineLifeCycle = pipelineLifeCycle)
   def withTags(tags: Map[String, Option[String]]) = copy(tags = this.tags ++ tags)
   def withParameters(parameters: Iterable[Parameter[_]]) = copy(parameters = parameters)
 
@@ -32,6 +34,7 @@ object DataPipelineDefWrapper {
     inner.hc,
     inner.pipelineName,
     inner.schedule,
+    inner.pipelineLifeCycle,
     () => inner.workflow,
     inner.tags,
     inner.parameters

--- a/core/src/main/scala/com/krux/hyperion/PipelineLifeCycle.scala
+++ b/core/src/main/scala/com/krux/hyperion/PipelineLifeCycle.scala
@@ -1,0 +1,7 @@
+package com.krux.hyperion
+
+trait PipelineLifeCycle {
+
+  def startPipeline(id: String, name: String, status: String)
+
+}


### PR DESCRIPTION
Feature #W-7379481
Adding additional capability for pipelines to have custom behavior when pipelines are started.  Pipelines can optionally implement the PipelineLifeCycle trait and implement startpipeline API for custom functionality.

In our current scenario, we want to notify and track all the pipelines started via Hyperion for further monitoring & management.